### PR TITLE
Pop up height increase

### DIFF
--- a/app/src/main/java/neth/iecal/questphone/ui/screens/pet/PetDialog.kt
+++ b/app/src/main/java/neth/iecal/questphone/ui/screens/pet/PetDialog.kt
@@ -492,7 +492,8 @@ fun PetDialog(
                             Column(
                                 modifier = Modifier
                                     .weight(1f)
-                                    .height(120.dp) // Fixed height for text area
+                                    // Fixed height for text area, might leave some white space
+                                    .height(135.dp)
                                     .verticalScroll(scroll) // Scroll if text overflows
                             ) {
                                 Text(


### PR DESCRIPTION
Increased the turtle's message height by 15:
![Screenshot From 2025-07-07 09-05-47](https://github.com/user-attachments/assets/f8b906fd-601e-4a35-8308-7bf4e07a290b)

as opposed to:
![image](https://github.com/user-attachments/assets/163a3b5e-3596-40d4-a7be-4b354becf14e)

It leaves some white space in some shorter dialogs so it may be worth it to center those height-wise

closes #5 